### PR TITLE
Feat/#3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ GoogleService-Info.plist
 
 ## User settings
 xcuserdata/
+*.xcconfig
 
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint

--- a/NABAMovie/NABAMovie.xcodeproj/project.pbxproj
+++ b/NABAMovie/NABAMovie.xcodeproj/project.pbxproj
@@ -326,6 +326,8 @@
 /* Begin XCBuildConfiguration section */
 		AAC89F692DBB9F82008EBD92 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = AAC89F412DBB9F80008EBD92 /* NABAMovie */;
+			baseConfigurationReferenceRelativePath = Resources/Secrets.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -357,6 +359,8 @@
 		};
 		AAC89F6A2DBB9F82008EBD92 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = AAC89F412DBB9F80008EBD92 /* NABAMovie */;
+			baseConfigurationReferenceRelativePath = Resources/Secrets.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/NABAMovie/NABAMovie/Data/Network/DTO/MovieDetailDTO.swift
+++ b/NABAMovie/NABAMovie/Data/Network/DTO/MovieDetailDTO.swift
@@ -1,0 +1,154 @@
+//
+//  MovieDetailDTO.swift
+//  NABAMovie
+//
+//  Created by 박주성 on 4/25/25.
+//
+
+import Foundation
+
+// MARK: - MovieDetailDTO
+
+struct MovieDetailDTO: Decodable {
+    let id: Int
+    let title: String
+    let genres: [Genre]
+    let credits: Credits
+    let overview: String
+    let popularity: Double
+    let posterPath: String
+    let releaseDate: String
+    let runtime: Int
+    let voteAverage: Double
+    let voteCount: Int
+    let releaseDates: ReleaseDates?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case genres
+        case credits
+        case overview
+        case popularity
+        case posterPath = "poster_path"
+        case releaseDate = "release_date"
+        case runtime
+        case voteAverage = "vote_average"
+        case voteCount = "vote_count"
+        case releaseDates = "release_dates"
+    }
+}
+
+// MARK: - Genre
+
+struct Genre: Decodable {
+    let id: Int
+    let name: String
+}
+
+// MARK: - Credits
+
+struct Credits: Decodable {
+    let cast, crew: [Cast]
+}
+
+struct Cast: Decodable {
+    let name: String
+    let job: String?
+}
+
+// MARK: - ReleaseDates
+
+struct ReleaseDates: Decodable {
+    let results: [ReleaseDatesResult]?
+}
+
+struct ReleaseDatesResult: Decodable {
+    let iso3166_1: String?
+    let releaseDates: [ReleaseDate]?
+    
+    enum CodingKeys: String, CodingKey {
+        case iso3166_1 = "iso_3166_1"
+        case releaseDates = "release_dates"
+    }
+}
+
+struct ReleaseDate: Codable {
+    let certification: String?
+    let releaseDate: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case certification
+        case releaseDate = "release_date"
+    }
+}
+
+// MARK: - Extension
+
+extension MovieDetailDTO {
+    func toEntity() -> MovieEntity {
+        // 장르 이름만 3개까지만 추출
+        let genreNames = genres.prefix(3).map { $0.name }
+        
+        // 감독 찾기
+        let director = credits.crew.first(where: { $0.job == "Director" })?.name
+        
+        // 출연 배우 3명까지만 추출
+        let actorsName = credits.cast.prefix(3).compactMap { $0.name }
+        
+        // 평점 소수점 둘째자리까지만
+        let roundedVoteAverage = Double(round(100 * voteAverage) / 100)
+        
+        // 포스터 URL
+        let baseURL = "https://image.tmdb.org/t/p/w780"
+        let fullPosterURL = baseURL + posterPath
+        
+        // 관람등급 필터링
+        let certification = {
+            let cert = releaseDates?.results?
+                .first(where: { $0.iso3166_1 == "KR" })?
+                .releaseDates?
+                .first?
+                .certification
+            return (cert?.isEmpty == true) ? nil : cert
+        }()
+        
+        return MovieEntity(
+            movieID: id,
+            title: title,
+            genre: genreNames,
+            director: director,
+            actors: actorsName,
+            releaseDate: findFormattedReleaseDate(from: releaseDates?.results),
+            runtime: runtime,
+            voteAverage: roundedVoteAverage,
+            voteCount: voteCount,
+            overview: overview.isEmpty ? nil : overview,
+            posterImageURL: fullPosterURL,
+            certification: certification,
+        )
+    }
+    
+    private func findFormattedReleaseDate(from releaseDates: [ReleaseDatesResult]?) -> String? {
+        guard let dateString = releaseDates?
+            .first(where: { $0.iso3166_1 == "KR" })?
+            .releaseDates?
+            .first?
+            .releaseDate else {
+            return nil
+        }
+        
+        let inputFormatter = DateFormatter()
+        inputFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+        inputFormatter.locale = Locale(identifier: "en_US_POSIX")
+
+        let outputFormatter = DateFormatter()
+        outputFormatter.dateFormat = "dd.MM.yyyy"
+
+        if let date = inputFormatter.date(from: dateString) {
+            return outputFormatter.string(from: date)
+        } else {
+            return nil
+        }
+    }
+}

--- a/NABAMovie/NABAMovie/Data/Network/DTO/MovieDetailDTO.swift
+++ b/NABAMovie/NABAMovie/Data/Network/DTO/MovieDetailDTO.swift
@@ -100,8 +100,10 @@ extension MovieDetailDTO {
         let roundedVoteAverage = Double(round(100 * voteAverage) / 100)
         
         // 포스터 URL
-        let baseURL = "https://image.tmdb.org/t/p/w780"
-        let fullPosterURL = baseURL + posterPath
+        let fullPosterURL: String? = {
+            guard !posterPath.isEmpty else { return nil }
+            return TMDB.posterBaseURL + posterPath
+        }()
         
         // 관람등급 필터링
         let certification = {

--- a/NABAMovie/NABAMovie/Data/Network/DTO/MovieImageDTO.swift
+++ b/NABAMovie/NABAMovie/Data/Network/DTO/MovieImageDTO.swift
@@ -1,0 +1,32 @@
+//
+//  MovieImageDTO.swift
+//  NABAMovie
+//
+//  Created by 박주성 on 4/28/25.
+//
+
+import Foundation
+
+struct MovieImageDTO: Decodable {
+    let backdrops: [Backdrop]
+}
+
+// MARK: - Backdrop
+struct Backdrop: Decodable {
+    let filePath: String
+
+    enum CodingKeys: String, CodingKey {
+        case filePath = "file_path"
+    }
+}
+
+extension MovieImageDTO {
+    func toEntity() -> [MovieStillsEntity] {
+        backdrops
+            .prefix(10)
+            .compactMap {
+            guard let url = URL(string: TMDB.backDropBaseURL + $0.filePath) else { return nil }
+            return MovieStillsEntity(imageURL: url)
+        }
+    }
+}

--- a/NABAMovie/NABAMovie/Data/Network/DTO/NowPlayingMovieDTO.swift
+++ b/NABAMovie/NABAMovie/Data/Network/DTO/NowPlayingMovieDTO.swift
@@ -1,0 +1,22 @@
+//
+//  NowPlayingDTO.swift
+//  NABAMovie
+//
+//  Created by 박주성 on 4/25/25.
+//
+
+import Foundation
+
+struct NowPlayingMovieDTO: Decodable {
+    let results: [NowPlayingMoviesID]
+}
+
+struct NowPlayingMoviesID: Decodable {
+    let id: Int
+}
+
+extension NowPlayingMovieDTO {
+    func limitedIDs(limit: Int = 10) -> [Int] {
+        results.prefix(limit).map { $0.id }
+    }
+}

--- a/NABAMovie/NABAMovie/Data/Network/DTO/SearchMovieDTO.swift
+++ b/NABAMovie/NABAMovie/Data/Network/DTO/SearchMovieDTO.swift
@@ -5,7 +5,6 @@
 //  Created by 박주성 on 4/28/25.
 //
 
-
 import Foundation
 
 struct SearchMovieDTO: Decodable {

--- a/NABAMovie/NABAMovie/Data/Network/DTO/SearchMovieDTO.swift
+++ b/NABAMovie/NABAMovie/Data/Network/DTO/SearchMovieDTO.swift
@@ -1,0 +1,23 @@
+//
+//  SearchMovieDTO.swift
+//  NABAMovie
+//
+//  Created by 박주성 on 4/28/25.
+//
+
+
+import Foundation
+
+struct SearchMovieDTO: Decodable {
+    let results: [SearchMovieIds]
+}
+
+struct SearchMovieIds: Decodable {
+    let id: Int
+}
+
+extension SearchMovieDTO {
+    func toIDs() -> [Int] {
+        results.map { $0.id }
+    }
+}

--- a/NABAMovie/NABAMovie/Data/Network/DTO/UpComingMovieDTO.swift
+++ b/NABAMovie/NABAMovie/Data/Network/DTO/UpComingMovieDTO.swift
@@ -1,0 +1,22 @@
+//
+//  UpComingMovieDTO.swift
+//  NABAMovie
+//
+//  Created by 박주성 on 4/25/25.
+//
+
+import Foundation
+
+struct UpComingMovieDTO: Decodable {
+    let results: [UpComingMoviesID]
+}
+
+struct UpComingMoviesID: Decodable {
+    let id: Int
+}
+
+extension UpComingMovieDTO {
+    func limitedIDs(limit: Int = 10) -> [Int] {
+        results.prefix(limit).map { $0.id }
+    }
+}

--- a/NABAMovie/NABAMovie/Data/Network/MovieNetworkManager.swift
+++ b/NABAMovie/NABAMovie/Data/Network/MovieNetworkManager.swift
@@ -1,0 +1,131 @@
+//
+//  MovieNetworkManager.swift
+//  NABAMovie
+//
+//  Created by 박주성 on 4/25/25.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+    case invalidURL       // URL 생성 실패
+    case responseError    // 서버 응답 오류
+    case decodingError    // JSON 디코딩 실패
+}
+
+final class MovieNetworkManager {
+    
+    // MARK: - 현재 상영작 불러오기
+    
+    func fetchNowPlayingMovies() async throws -> NowPlayingMovieDTO {
+        var components = URLComponents(string: TMDB.baseURL + TMDB.NowPlaying.path)
+        components?.queryItems = [
+            URLQueryItem(name: "api_key", value: TMDB.apiKey),
+            URLQueryItem(name: "language", value: TMDB.language)
+        ]
+        
+        guard let urlString = components?.url?.absoluteString,
+              let url = URL(string: urlString)
+        else {
+            throw NetworkError.invalidURL
+        }
+        
+        let (data, response) = try await URLSession.shared.data(from: url)
+        
+        guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+            throw NetworkError.responseError
+        }
+        
+        guard let dto = try? JSONDecoder().decode(NowPlayingMovieDTO.self, from: data) else {
+            throw NetworkError.decodingError
+        }
+        
+        return dto
+    }
+    
+    // MARK: - 상영 예정작 불러오기
+    
+    func fetchUpComingMovies() async throws -> UpComingMovieDTO {
+        var components = URLComponents(string: TMDB.baseURL + TMDB.UpComing.path)
+        components?.queryItems = [
+            URLQueryItem(name: "api_key", value: TMDB.apiKey),
+            URLQueryItem(name: "language", value: TMDB.language)
+        ]
+        
+        guard let urlString = components?.url?.absoluteString,
+              let url = URL(string: urlString)
+        else {
+            throw NetworkError.invalidURL
+        }
+        
+        let (data, response) = try await URLSession.shared.data(from: url)
+        
+        guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+            throw NetworkError.responseError
+        }
+        
+        guard let dto = try? JSONDecoder().decode(UpComingMovieDTO.self, from: data) else {
+            throw NetworkError.decodingError
+        }
+        
+        return dto
+    }
+    
+    // MARK: - 영화 검색 결과 불러오기
+    
+    func fetchSearchMovies(keyword: String) async throws -> SearchMovieDTO {
+        var components = URLComponents(string: TMDB.baseURL + TMDB.Search.path)
+        components?.queryItems = [
+            URLQueryItem(name: "api_key", value: TMDB.apiKey),
+            URLQueryItem(name: "language", value: TMDB.language),
+            URLQueryItem(name: "query", value: keyword)
+        ]
+        
+        guard let urlString = components?.url?.absoluteString,
+              let url = URL(string: urlString)
+        else {
+            throw NetworkError.invalidURL
+        }
+        
+        let (data, response) = try await URLSession.shared.data(from: url)
+        
+        guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+            throw NetworkError.responseError
+        }
+        
+        guard let dto = try? JSONDecoder().decode(SearchMovieDTO.self, from: data) else {
+            throw NetworkError.decodingError
+        }
+        
+        return dto
+    }
+    
+    // MARK: - 영화 상세정보 불러오기
+    
+    func fetchMovieDetail(movieID: Int) async throws -> MovieDetailDTO {
+        var components = URLComponents(string: TMDB.baseURL + TMDB.Detail.path + "\(movieID)")
+        components?.queryItems = [
+            URLQueryItem(name: "api_key", value: TMDB.apiKey),
+            URLQueryItem(name: "language", value: TMDB.language),
+            URLQueryItem(name: "append_to_response", value: TMDB.Detail.appendToResponse)
+        ]
+        
+        guard let urlString = components?.url?.absoluteString,
+              let url = URL(string: urlString)
+        else {
+            throw NetworkError.invalidURL
+        }
+        
+        let (data, response) = try await URLSession.shared.data(from: url)
+        
+        guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+            throw NetworkError.responseError
+        }
+        
+        guard let dto = try? JSONDecoder().decode(MovieDetailDTO.self, from: data) else {
+            throw NetworkError.decodingError
+        }
+        
+        return dto
+    }
+}

--- a/NABAMovie/NABAMovie/Data/Network/MovieNetworkManager.swift
+++ b/NABAMovie/NABAMovie/Data/Network/MovieNetworkManager.swift
@@ -103,7 +103,7 @@ final class MovieNetworkManager {
     // MARK: - 영화 상세정보 불러오기
     
     func fetchMovieDetail(movieID: Int) async throws -> MovieDetailDTO {
-        var components = URLComponents(string: TMDB.baseURL + TMDB.Detail.path + "\(movieID)")
+        var components = URLComponents(string: TMDB.baseURL + TMDB.Detail.path(movieID: movieID))
         components?.queryItems = [
             URLQueryItem(name: "api_key", value: TMDB.apiKey),
             URLQueryItem(name: "language", value: TMDB.language),
@@ -123,6 +123,33 @@ final class MovieNetworkManager {
         }
         
         guard let dto = try? JSONDecoder().decode(MovieDetailDTO.self, from: data) else {
+            throw NetworkError.decodingError
+        }
+        
+        return dto
+    }
+    
+    // MARK: - 영화 이미지 불러오기
+    
+    func fetchMovieImages(movieID: Int) async throws -> MovieImageDTO {
+        var components = URLComponents(string: TMDB.baseURL + TMDB.Images.path(movieID: movieID))
+        components?.queryItems = [
+            URLQueryItem(name: "api_key", value: TMDB.apiKey)
+        ]
+        
+        guard let urlString = components?.url?.absoluteString,
+              let url = URL(string: urlString)
+        else {
+            throw NetworkError.invalidURL
+        }
+        
+        let (data, response) = try await URLSession.shared.data(from: url)
+        
+        guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+            throw NetworkError.responseError
+        }
+        
+        guard let dto = try? JSONDecoder().decode(MovieImageDTO.self, from: data) else {
             throw NetworkError.decodingError
         }
         

--- a/NABAMovie/NABAMovie/Data/Repositories/MovieRepositoryImpl.swift
+++ b/NABAMovie/NABAMovie/Data/Repositories/MovieRepositoryImpl.swift
@@ -1,0 +1,56 @@
+//
+//  MovieRepositoryImpl.swift
+//  NABAMovie
+//
+//  Created by 박주성 on 4/26/25.
+//
+
+import Foundation
+
+final class MovieRepositoryImpl: MovieRepository {
+    
+    private let networkManager: MovieNetworkManager
+    
+    init(networkManager: MovieNetworkManager) {
+        self.networkManager = networkManager
+    }
+    
+    func fetchNowPlayingMoviesDetail() async throws -> [MovieEntity] {
+        let dto = try await networkManager.fetchNowPlayingMovies()
+        let nowPlayingMoviesDetail = try await fetchMoviesDetail(moviesID: dto.limitedIDs())
+        return nowPlayingMoviesDetail.map { $0.toEntity() }
+    }
+    
+    func fetchUpComingMoviesDetail() async throws -> [MovieEntity] {
+        let dto = try await networkManager.fetchUpComingMovies()
+        let nowPlayingMoviesDetail = try await fetchMoviesDetail(moviesID: dto.limitedIDs())
+        return nowPlayingMoviesDetail.map { $0.toEntity() }
+    }
+    
+    func fetchSearchMoviesDetail(for keyword: String) async throws -> [MovieEntity] {
+        let dto = try await networkManager.fetchSearchMovies(keyword: keyword)
+        let searchMoviesDetail = try await fetchMoviesDetail(moviesID: dto.toIDs())
+        return searchMoviesDetail.map { $0.toEntity() }
+    }
+    
+    private func fetchMoviesDetail(moviesID: [Int]) async throws -> [MovieDetailDTO] {
+        return try await withThrowingTaskGroup(of: (Int, MovieDetailDTO).self) { group in
+            var movies: [(Int, MovieDetailDTO)] = []
+            
+            for (index, movieID) in moviesID.enumerated() {
+                group.addTask {
+                    let movieDetail = try await self.networkManager.fetchMovieDetail(movieID: movieID)
+                    return (index, movieDetail)
+                }
+            }
+            
+            for try await movie in group {
+                movies.append(movie)
+            }
+            
+            return movies
+                .sorted { $0.0 < $1.0 }
+                .map { $0.1 }
+        }
+    }
+}

--- a/NABAMovie/NABAMovie/Data/Repositories/MovieRepositoryImpl.swift
+++ b/NABAMovie/NABAMovie/Data/Repositories/MovieRepositoryImpl.swift
@@ -53,4 +53,9 @@ final class MovieRepositoryImpl: MovieRepository {
                 .map { $0.1 }
         }
     }
+    
+    func fetchMoviesStills(for movieID: Int) async throws -> [MovieStillsEntity] {
+        let dto = try await networkManager.fetchMovieImages(movieID: movieID)
+        return dto.toEntity()
+    }
 }

--- a/NABAMovie/NABAMovie/Domain/Entity/MovieEntity.swift
+++ b/NABAMovie/NABAMovie/Domain/Entity/MovieEntity.swift
@@ -1,0 +1,23 @@
+//
+//  MovieEntity.swift
+//  NABAMovie
+//
+//  Created by 박주성 on 4/26/25.
+//
+
+import Foundation
+
+struct MovieEntity {
+    let movieID: Int                // 영화 ID
+    let title: String               // 영화 제목
+    let genre: [String]             // 장르
+    let director: String?           // 영화 감독
+    let actors: [String]            // 출연 배우 (3명)
+    let releaseDate: String?        // 영화 개봉일
+    let runtime: Int                // 상영시간
+    let voteAverage: Double         // 평점(소수점 두자리만 사용)
+    let voteCount: Int              // 평가 인원 수
+    let overview: String?           // 줄거리
+    let posterImageURL: String      // 포스터 이미지 URL
+    let certification: String?      // 관람 등급
+}

--- a/NABAMovie/NABAMovie/Domain/Entity/MovieEntity.swift
+++ b/NABAMovie/NABAMovie/Domain/Entity/MovieEntity.swift
@@ -18,6 +18,6 @@ struct MovieEntity {
     let voteAverage: Double         // 평점(소수점 두자리만 사용)
     let voteCount: Int              // 평가 인원 수
     let overview: String?           // 줄거리
-    let posterImageURL: String      // 포스터 이미지 URL
+    let posterImageURL: String?      // 포스터 이미지 URL
     let certification: String?      // 관람 등급
 }

--- a/NABAMovie/NABAMovie/Domain/Entity/MovieStillsEntity.swift
+++ b/NABAMovie/NABAMovie/Domain/Entity/MovieStillsEntity.swift
@@ -1,0 +1,12 @@
+//
+//  MovieStillsEntity.swift
+//  NABAMovie
+//
+//  Created by 박주성 on 4/28/25.
+//
+
+import Foundation
+
+struct MovieStillsEntity {
+    let imageURL: URL
+}

--- a/NABAMovie/NABAMovie/Domain/Protocol/MovieRepository.swift
+++ b/NABAMovie/NABAMovie/Domain/Protocol/MovieRepository.swift
@@ -1,0 +1,14 @@
+//
+//  MovieRepository.swift
+//  NABAMovie
+//
+//  Created by 박주성 on 4/27/25.
+//
+
+import Foundation
+
+protocol MovieRepository {
+    func fetchNowPlayingMoviesDetail() async throws -> [MovieEntity]
+    func fetchUpComingMoviesDetail() async throws -> [MovieEntity]
+    func fetchSearchMoviesDetail(for keyword: String) async throws -> [MovieEntity]
+}

--- a/NABAMovie/NABAMovie/Domain/Protocol/MovieRepository.swift
+++ b/NABAMovie/NABAMovie/Domain/Protocol/MovieRepository.swift
@@ -11,4 +11,5 @@ protocol MovieRepository {
     func fetchNowPlayingMoviesDetail() async throws -> [MovieEntity]
     func fetchUpComingMoviesDetail() async throws -> [MovieEntity]
     func fetchSearchMoviesDetail(for keyword: String) async throws -> [MovieEntity]
+    func fetchMoviesStills(for movieID: Int) async throws -> [MovieStillsEntity]
 }

--- a/NABAMovie/NABAMovie/Domain/UseCase/FetchHomeScreenMoviesUseCase.swift
+++ b/NABAMovie/NABAMovie/Domain/UseCase/FetchHomeScreenMoviesUseCase.swift
@@ -1,0 +1,29 @@
+//
+//  FetchHomeScreenMoviesUseCase.swift
+//  NABAMovie
+//
+//  Created by 박주성 on 4/26/25.
+//
+
+import Foundation
+
+final class FetchHomeScreenMoviesUseCase {
+    private let repository: MovieRepository
+    
+    init(repository: MovieRepository) {
+        self.repository = repository
+    }
+    
+    func execute() async -> Result<([MovieEntity], [MovieEntity]), Error> {
+        do {
+            async let nowPlayingMovies = repository.fetchNowPlayingMoviesDetail()
+            async let upcomingMovies = repository.fetchUpComingMoviesDetail()
+            
+            let (nowPlaying, upcoming) = try await (nowPlayingMovies, upcomingMovies)
+            
+            return .success((nowPlaying, upcoming))
+        } catch {
+            return .failure(error)
+        }
+    }
+}

--- a/NABAMovie/NABAMovie/Domain/UseCase/FetchMovieStillsUseCase.swift
+++ b/NABAMovie/NABAMovie/Domain/UseCase/FetchMovieStillsUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  FetchMovieStillsUseCase.swift
+//  NABAMovie
+//
+//  Created by 박주성 on 4/28/25.
+//
+
+import Foundation
+
+final class FetchMovieStillsUseCase {
+    private let repository: MovieRepository
+    
+    init(repository: MovieRepository) {
+        self.repository = repository
+    }
+    
+    func execute(for movieID: Int) async -> Result<[MovieStillsEntity], Error> {
+        do {
+            let stills = try await repository.fetchMoviesStills(for: movieID)
+            return .success(stills)
+        } catch {
+            return .failure(error)
+        }
+    }
+}

--- a/NABAMovie/NABAMovie/Domain/UseCase/FetchSearchMoviesUseCase.swift
+++ b/NABAMovie/NABAMovie/Domain/UseCase/FetchSearchMoviesUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  FetchSearchMoviesUseCase.swift
+//  NABAMovie
+//
+//  Created by 박주성 on 4/28/25.
+//
+
+import Foundation
+
+final class FetchSearchMoviesUseCase {
+    let repository: MovieRepository
+    
+    init(repository: MovieRepository) {
+        self.repository = repository
+    }
+    
+    func execute(for keyword: String) async -> Result<[MovieEntity], Error> {
+        do {
+            let searchResults = try await repository.fetchSearchMoviesDetail(for: keyword)
+            return .success(searchResults)
+        } catch {
+            return .failure(error)
+        }
+    }
+}

--- a/NABAMovie/NABAMovie/Domain/UseCase/FetchSearchMoviesUseCase.swift
+++ b/NABAMovie/NABAMovie/Domain/UseCase/FetchSearchMoviesUseCase.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 final class FetchSearchMoviesUseCase {
-    let repository: MovieRepository
+    private let repository: MovieRepository
     
     init(repository: MovieRepository) {
         self.repository = repository

--- a/NABAMovie/NABAMovie/Resources/Info.plist
+++ b/NABAMovie/NABAMovie/Resources/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>TMDB_API_KEY</key>
+	<string>$(TMDB_API_KEY)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/NABAMovie/NABAMovie/Utils/Constants.swift
+++ b/NABAMovie/NABAMovie/Utils/Constants.swift
@@ -1,0 +1,33 @@
+//
+//  Constants.swift
+//  NABAMovie
+//
+//  Created by 박주성 on 4/28/25.
+//
+
+
+import Foundation
+
+enum TMDB {
+    static let baseURL = "https://api.themoviedb.org/3"
+    static let apiKey = Bundle.main.object(forInfoDictionaryKey: "TMDB_API_KEY") as! String
+    static let language = "ko-KR"
+    static let posterBaseURL = "https://image.tmdb.org/t/p/w500"
+    
+    enum NowPlaying {
+        static let path = "/movie/now_playing"
+    }
+    
+    enum UpComing {
+        static let path = "/movie/upcoming"
+    }
+    
+    enum Search {
+        static let path = "/search/movie"
+    }
+    
+    enum Detail {
+        static let path = "/movie/"
+        static let appendToResponse = "credits,release_dates"
+    }
+}

--- a/NABAMovie/NABAMovie/Utils/Constants.swift
+++ b/NABAMovie/NABAMovie/Utils/Constants.swift
@@ -12,7 +12,8 @@ enum TMDB {
     static let baseURL = "https://api.themoviedb.org/3"
     static let apiKey = Bundle.main.object(forInfoDictionaryKey: "TMDB_API_KEY") as! String
     static let language = "ko-KR"
-    static let posterBaseURL = "https://image.tmdb.org/t/p/w500"
+    static let posterBaseURL = "https://image.tmdb.org/t/p/w780"
+    static let backDropBaseURL = "https://image.tmdb.org/t/p/w1280"
     
     enum NowPlaying {
         static let path = "/movie/now_playing"
@@ -27,7 +28,15 @@ enum TMDB {
     }
     
     enum Detail {
-        static let path = "/movie/"
+        static func path(movieID: Int) -> String {
+            return "/movie/\(movieID)"
+        }
         static let appendToResponse = "credits,release_dates"
+    }
+    
+    enum Images {
+        static func path(movieID: Int) -> String {
+            return "/movie/\(movieID)/images"
+        }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- close #3

## 📌 변경 사항 및 이유
- 홈 화면, 검색 화면의 **Domain 레이어와 Data 레이어** 구현
- 영화 데이터를 가져오기 위한 **MovieNetworkManager를 생성**하고, 필요한 **DTO 정의**
- 영화의 스틸컷을 불러오는 **UseCase 및 Data 레이어** 추가
- 보안을 위해 **.xcconfig 파일**을 활용하여 API 키 숨김
- .xcconfig 적용을 위해 프로젝트 파일(Project Settings)과 .gitignore 파일 수정
- 포스터 경로 타입을 `String?`로 **수정**하고, 관련 코드를 정리

## 📌 PR Point
- Domain-Data 레이어 간의 의존성 연결 방식
- MovieDetailDTO -> MovieEntity 변환 과정에서의 예외처리 방식
- 포스터 URL 타입 변경 (`String?`) 처리 부분
- .xcconfig 적용 후 빌드 및 실행 여부
- .gitignore 수정 사항 적용 여부

## 📌 참고 사항
- .xcconfig는 Resource폴더로 추가
- .xcconfig 적용 안될경우 **PROJECT - Info - Configurations(Debug/Release)** 에서 다시 추가 및 빌드